### PR TITLE
Add branch/25.08 to update workflow matrix

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: [ branch/24.08 ] # list all branches to check
+        branch: [ branch/24.08, branch/25.08 ] # list all branches to check
     
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Adds branch/25.08 to the update workflow matrix so the external data checker runs for both maintained release branches.