### PR TITLE
Update runtime-version to 25.08 on master

### DIFF
--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -3,7 +3,7 @@ branch: '25.08'
 build-extension: true
 sdk: org.freedesktop.Sdk//25.08
 runtime: com.visualstudio.code
-runtime-version: stable
+runtime-version: 25.08
 separate-locales: false
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
## Summary
- update `runtime-version` in `com.visualstudio.code.tool.podman.yml` from `stable` to `25.08`

## Testing
- not run (manifest-only change)